### PR TITLE
MSKINS-77 - Add Github ribbon for maven-skins to fluido site

### DIFF
--- a/maven-fluido-skin/src/it/mskins-22/src/site/site.xml
+++ b/maven-fluido-skin/src/it/mskins-22/src/site/site.xml
@@ -35,7 +35,7 @@
   <custom>
     <fluidoSkin>
       <gitHub>
-        <projectId>99soft/backport-spi</projectId>
+        <projectId>apache/maven-skins</projectId>
         <ribbonOrientation>right</ribbonOrientation>
         <ribbonColor>black</ribbonColor>
       </gitHub>

--- a/maven-fluido-skin/src/it/mskins-22_default/src/site/site.xml
+++ b/maven-fluido-skin/src/it/mskins-22_default/src/site/site.xml
@@ -35,7 +35,7 @@
   <custom>
     <fluidoSkin>
       <gitHub>
-        <projectId>99soft/backport-spi</projectId>
+        <projectId>apache/maven-skins</projectId>
       </gitHub>
     </fluidoSkin>
   </custom>

--- a/maven-fluido-skin/src/it/mskins-22_topbar/src/site/site.xml
+++ b/maven-fluido-skin/src/it/mskins-22_topbar/src/site/site.xml
@@ -37,7 +37,7 @@
       <topBarEnabled>true</topBarEnabled>
       <sideBarEnabled>false</sideBarEnabled>
       <gitHub>
-        <projectId>99soft/backport-spi</projectId>
+        <projectId>apache/maven-skins</projectId>
         <ribbonOrientation>right</ribbonOrientation>
         <ribbonColor>black</ribbonColor>
       </gitHub>

--- a/maven-fluido-skin/src/site/apt/index.apt.vm
+++ b/maven-fluido-skin/src/site/apt/index.apt.vm
@@ -258,7 +258,7 @@ Welcome to ${project.name}!
   <custom>
     <fluidoSkin>
       <gitHub>
-        <projectId>99soft/backport-spi</projectId>
+        <projectId>apache/maven-skins</projectId>
         <ribbonOrientation>right</ribbonOrientation>
         <ribbonColor>black</ribbonColor>
       </gitHub>

--- a/maven-fluido-skin/src/site/site.xml
+++ b/maven-fluido-skin/src/site/site.xml
@@ -37,6 +37,11 @@ under the License.
     <fluidoSkin>
       <googlePlusOne />
       <facebookLike />
+      <gitHub>
+        <projectId>apache/maven-skins</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>red</ribbonColor>
+      </gitHub>
     </fluidoSkin>
   </custom>
 


### PR DESCRIPTION
Proposed fix for MSKINS-77 which adds a Github ribbon and also updates the documentation and IT to point to apache/maven-skins.
